### PR TITLE
Eliminate NaN in PDF/CDF when <E> <= 0.

### DIFF
--- a/python/asteria/source.py
+++ b/python/asteria/source.py
@@ -42,13 +42,16 @@ class Source:
         # parameterized by mean energy and pinch parameter alpha. True for
         # nearly all CCSN models.
         self.energy_pdf = lambda a, Ea, E: \
+            np.zeros_like(E) if Ea <= 0 else \
             np.exp((1 + a) * np.log(1 + a) - loggamma(1 + a) + a * np.log(E) - \
                    (1 + a) * np.log(Ea) - (1 + a) * (E / Ea))
                    
         self.v_energy_pdf =  np.vectorize(self.energy_pdf, excluded=['E'], signature='(1,n),(1,n)->(m,n)' )
 
         # Energy CDF, useful for random energy sampling.
-        self.energy_cdf = lambda a, Ea, E: gdtr(1., a + 1., (a + 1.) * (E / Ea))
+        self.energy_cdf = lambda a, Ea, E: \
+            np.zeros_like(E) if Ea <= 0 else \
+            gdtr(1., a + 1., (a + 1.) * (E / Ea))
 
     def parts_by_index(self, x, n): 
         """Returns a list of size-n numpy arrays containing indices for the 


### PR DESCRIPTION
Fixed issue in generation of neutrino spectra when average energy <E> is less than zero, which is the case at pre-explosion times in some models for flavors other than nu_e. Failing to check will result in NaN appearing the energy PDF at some times.