### PR TITLE
merge ignore-scratch onto master

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ export ASTERIA=/path/to/asteria_folder
 
 will install softlinks in your python path to the source in your git checkout.
 
+## Ignored files
+Files saved in the subdirectories below will be ignored.
+
+```
+ASTERIA/scratch
+ASTERIA/data/processed
+```
+
+
 ## License
 
 [BSD License](LICENSE.rst)

--- a/data/processed/.gitignore
+++ b/data/processed/.gitignore
@@ -1,0 +1,3 @@
+# ignore the preprocessed simulations ASTERIA saves to this directory
+*.h5
+!.gitignore

--- a/scratch/.gitignore
+++ b/scratch/.gitignore
@@ -1,0 +1,3 @@
+# ignore all files saved to this directory by users
+*
+!.gitignore


### PR DESCRIPTION
These commits add `scratch/` and `data/processed` directories with `.gitignore`s in each that makes git ignore the content of these folders. This was partially to alleviate the issues @nuberoi  has had with the Github windows app. The content of `data/processed/` should not be committed, as these files can be large in size and `scratch/` is a useful user space.

