### PR TITLE
Merge osc-debug onto master

### DIFF
--- a/python/asteria/neutrino.py
+++ b/python/asteria/neutrino.py
@@ -80,6 +80,7 @@ class _FlavorMeta(EnumMeta):
                   'is_electron'           : cls.is_electron,
                   'is_neutrino'           : cls.is_neutrino,
                   'is_antineutrino'       : cls.is_antineutrino,
+                  'oscillates_to'         : cls.oscillates_to,
                   'requests'              : requests }
         classdict.update({ key : val for key, val in fields.items()})
         
@@ -168,6 +169,13 @@ class Flavor(Enum, metaclass=_FlavorMeta):
     @property
     def is_antineutrino(self):
         return self.value in (Flavor.nu_e_bar.value, Flavor.nu_x_bar.value)
+
+    @property
+    def oscillates_to(self):
+        if self.is_electron:
+            return Flavor.nu_x if self.is_neutrino else Flavor.nu_x_bar
+        else:
+            return Flavor.nu_e if self.is_neutrino else Flavor.nu_e_bar
 
 
 class ValueCI(object):

--- a/python/asteria/oscillation.py
+++ b/python/asteria/oscillation.py
@@ -64,3 +64,51 @@ class SimpleMixing(object):
         nu_x_bar = [(a + b)/2 for a, b in zip(nu_list[1], nu_list[3])]
         nu_new = np.asarray([nu_e, nu_e_bar, nu_x, nu_x_bar])
         return nu_new
+
+
+class USSRMixing(object):
+    """Class that does very simple SN neutrino flavor mixing. Based on
+    calculation in USSR.
+    """
+
+    def __init__(self):
+        '''Initializes the PMNS Matrix (Taken from USSR- OUTDATED!!)
+
+        Parameters
+        ----------
+        t12: float
+             Mixing angle
+        '''
+        pmns = np.asarray( [[0.825,  0.546,  0.148],
+                            [-0.490, 0.562,  0.665],
+                            [0.280, -0.621,  0.732]])
+        self.P_nu_e = pmns[0, 1] ** 2
+        self.P_nu_e_bar = pmns[0, 0] ** 2
+        self.P_nu_x = 0.5 * (1 + self.P_nu_e)
+        self.P_nu_x_bar = 0.5 * (1 + self.P_nu_e_bar)
+
+    def normal_mixing(self, nu_list):
+        """Performs flavor oscillations as per normal hierarchy.
+
+        Parameters
+        ----------
+        nu_list : ndarray
+            neutrino fluxes ordered by flavor (nu_e, nu_e_bar, nu_x, nu_x_bar)
+
+        Returns
+        -------
+        nu_new = ndarray
+            neutrino fluxes after mixing (nu_e, nu_e_bar, nu_x, nu_x_bar)
+        """
+
+        nu_e = self.P_nu_e*nu_list[0] + (1-self.P_nu_e)*nu_list[2]
+        nu_x = self.P_nu_x*nu_list[2] + (1-self.P_nu_x)*nu_list[0]
+        nu_e_bar = self.P_nu_e_bar*nu_list[1] + (1-self.P_nu_e_bar)*nu_list[3]
+        nu_x_bar = self.P_nu_x_bar*nu_list[3] + (1-self.P_nu_x_bar)*nu_list[1]
+        nu_new = np.asarray([nu_e, nu_e_bar, nu_x, nu_x_bar])
+        return nu_new
+
+    def inverted_mixing(self, nu_list):
+        """Performs flavor oscillations as per inverted hierarchy.
+        IN THE USSR IMPLEMENTATION THIS IS THE SAME AS NORMAL"""
+        return self.normal_mixing(nu_list)

--- a/python/asteria/source.py
+++ b/python/asteria/source.py
@@ -279,7 +279,7 @@ class Source:
             def nu_spectrum(t, E, flavor):
                 return self.energy_spectrum(t, E, flavor) * self.get_flux(t, flavor)
         else:
-            nu_spectrum = mixing( self, flavor )
+            nu_spectrum = mixing(self, flavor)
 
         
         

--- a/python/asteria/source.py
+++ b/python/asteria/source.py
@@ -276,7 +276,8 @@ class Source:
         flux = self.get_flux( time, flavor ) # Unitless
         
         if mixing is None:
-            nu_spectrum = self.energy_spectrum
+            def nu_spectrum(t, E, flavor):
+                return self.energy_spectrum(t, E, flavor) * self.get_flux(t, flavor)
         else:
             nu_spectrum = mixing( self, flavor )
 


### PR DESCRIPTION
Implements fixes to the ASTERIA Oscillation code. This changes the call of the vital function `photonic_energy_per_vol`. Additionally, the example mixing class `USSRMixing` utilizes wrapper functions to mix the neutrino spectra. 

I suggest that `SimpleMixing` be re-written to use this convention (Wrapper functions).